### PR TITLE
Zahlungen nicht in der Vergangenheit ausführen

### DIFF
--- a/erpnextswiss/erpnextswiss/doctype/payment_proposal/payment_proposal.py
+++ b/erpnextswiss/erpnextswiss/doctype/payment_proposal/payment_proposal.py
@@ -205,8 +205,7 @@ class PaymentProposal(Document):
             else:
                 pay_date = datetime.strptime(execution_date, "%Y-%m-%d")
             if pay_date.date() < datetime.now().date():
-                pay_d
-                ate = datetime.now().date()
+                pay_date = datetime.now().date()
 
             new_payment = self.append('payments', {})
             new_payment.receiver = receiver_name

--- a/erpnextswiss/erpnextswiss/doctype/payment_proposal/payment_proposal.py
+++ b/erpnextswiss/erpnextswiss/doctype/payment_proposal/payment_proposal.py
@@ -200,6 +200,14 @@ class PaymentProposal(Document):
     def add_payment(self, receiver_name, iban, payment_type, address_line1, 
         address_line2, country, amount, currency, reference, execution_date, 
         esr_reference=None, esr_participation_number=None, bic=None, is_salary=0):
+            if isinstance(execution_date,datetime):
+                pay_date = execution_date
+            else:
+                pay_date = datetime.strptime(execution_date, "%Y-%m-%d")
+            if pay_date.date() < datetime.now().date():
+                pay_d
+                ate = datetime.now().date()
+
             new_payment = self.append('payments', {})
             new_payment.receiver = receiver_name
             new_payment.iban = iban
@@ -211,7 +219,7 @@ class PaymentProposal(Document):
             new_payment.amount = amount
             new_payment.currency = currency
             new_payment.reference = reference
-            new_payment.execution_date = execution_date
+            new_payment.execution_date = pay_date
             new_payment.esr_reference = esr_reference
             new_payment.esr_participation_number = esr_participation_number   
             new_payment.is_salary = is_salary   


### PR DESCRIPTION
Aktuell kann es bei Einzelzahlungen und ESR passieren, dass das Ausführungsdatum in der Vergangenheit liegt. 
Je nach Bank wird dann das komplette File (ZKB) oder nur einzelne Zahlungen (Raiffeisen) zurückgewiesen. Was zum einen ärgerlich ist zum anderen, gerade wenn nur einzelne Zahlungen zurückgewiesen werden zu Fehlern führen kann. 

Gruss Marco