### PR TITLE
Fix: Prevent JS error when entering an invalid postal code

### DIFF
--- a/erpnextswiss/public/js/swiss_common.js
+++ b/erpnextswiss/public/js/swiss_common.js
@@ -121,7 +121,7 @@ function get_city_from_pincode(pincode, target_field, state_field="", country=nu
             },
             async: false,
             callback: function(response) {
-                if (response.message && response.message.length > 0) {
+                if ((response.message) && (response.message.length > 0)) {
                     if (response.message.length == 1) {
                         // got exactly one city
                         var city = response.message[0].city;

--- a/erpnextswiss/public/js/swiss_common.js
+++ b/erpnextswiss/public/js/swiss_common.js
@@ -121,7 +121,7 @@ function get_city_from_pincode(pincode, target_field, state_field="", country=nu
             },
             async: false,
             callback: function(response) {
-                if (response.message) {
+                if (response.message && response.message.length > 0) {
                     if (response.message.length == 1) {
                         // got exactly one city
                         var city = response.message[0].city;


### PR DESCRIPTION
A little fix to a bug I just found.
When creating a new address and entering an invalid postal code, the search function returns an empty array, i.e. response.message is defined but response.message[0] is not. The function will then encounter an error on line 145 when it tries to access response.message[0].city. We can avoid this case by checking that the array is non-empty.