### PR TITLE
hotfix: correct broken readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ Refer to [https://github.com/libracore/erpnextswiss/wiki/Release-Notes](https://
 ## Data protection
 Please note that the provided sample QR code invoice uses a libracore server to process QR codes according to ISO 20022. The server is located in Switzerland, the invoice details will be transmitted to the server for processing.
 
-Please use a personal QR-code generation server to prevent data being sent to libracore. The source code is available from [https://github.com/lasalesi/phpqrcode](PhpQrCode)
+Please use a personal QR-code generation server to prevent data being sent to libracore. The source code is available from [https://github.com/lasalesi/phpqrcode](https://github.com/lasalesi/phpqrcode)


### PR DESCRIPTION
The current version of `README.md` includes a broken link to the **phpqrcode** project, wherein selecting the link leads to `https://github.com/libracore/erpnextswiss/blob/<BRANCH>/PhpQrCode`. This PR updates the link to correctly point to the project in question.